### PR TITLE
Add login screen using Firebase

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {
@@ -60,6 +61,10 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.0")
     implementation("androidx.activity:activity-compose:1.10.2")
     implementation("androidx.navigation:navigation-compose:2.8.0")
+
+    // Firebase Auth
+    implementation(platform("com.google.firebase:firebase-bom:33.1.0"))
+    implementation("com.google.firebase:firebase-auth-ktx")
 
 
     /* Tests básicos (opcional) */

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,16 +15,20 @@
         android:theme="@style/Theme.AppSecurity"
         tools:targetApi="31">
         <activity
-            android:name=".MainActivity"
+            android:name=".LoginActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.AppSecurity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.AppSecurity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/appsecurity/LoginActivity.kt
+++ b/app/src/main/java/com/example/appsecurity/LoginActivity.kt
@@ -1,0 +1,61 @@
+package com.example.appsecurity
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.example.appsecurity.ui.LoginScreen
+import com.example.appsecurity.ui.theme.AppSecurityTheme
+import com.google.firebase.FirebaseApp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
+
+class LoginActivity : ComponentActivity() {
+    private lateinit var auth: FirebaseAuth
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        FirebaseApp.initializeApp(this)
+        auth = Firebase.auth
+
+        if (isLoggedIn()) {
+            startActivity(Intent(this, MainActivity::class.java))
+            finish()
+            return
+        }
+
+        setContent {
+            AppSecurityTheme {
+                LoginScreen(
+                    onLogin = { e, p -> signIn(e, p) },
+                    onRegister = { /* TODO launch register */ },
+                    onRecover = { /* TODO launch recover */ }
+                )
+            }
+        }
+    }
+
+    private fun signIn(email: String, password: String) {
+        auth.signInWithEmailAndPassword(email, password).addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+                saveSession()
+                startActivity(Intent(this, MainActivity::class.java))
+                finish()
+            } else {
+                Toast.makeText(this, task.exception?.localizedMessage, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun isLoggedIn(): Boolean {
+        val prefs = getSharedPreferences("session", MODE_PRIVATE)
+        return prefs.getBoolean("logged_in", false) && auth.currentUser != null
+    }
+
+    private fun saveSession() {
+        val prefs = getSharedPreferences("session", MODE_PRIVATE)
+        prefs.edit().putBoolean("logged_in", true).apply()
+    }
+}

--- a/app/src/main/java/com/example/appsecurity/MainActivity.kt
+++ b/app/src/main/java/com/example/appsecurity/MainActivity.kt
@@ -4,13 +4,12 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.navigation.compose.rememberNavController
-
-// Data class representing a detection record
+import com.example.appsecurity.ui.theme.AppSecurityTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            SecureCamTheme {
+            AppSecurityTheme {
                 val navController = rememberNavController()
                 NavGraph(navController)
             }

--- a/app/src/main/java/com/example/appsecurity/ui/LoginScreen.kt
+++ b/app/src/main/java/com/example/appsecurity/ui/LoginScreen.kt
@@ -1,0 +1,65 @@
+package com.example.appsecurity.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LoginScreen(
+    onLogin: (String, String) -> Unit,
+    onRegister: () -> Unit,
+    onRecover: () -> Unit
+) {
+    var email by rememberSaveable { mutableStateOf("") }
+    var password by rememberSaveable { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        OutlinedTextField(
+            value = email,
+            onValueChange = { email = it },
+            label = { Text("Email") },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        OutlinedTextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Contraseña") },
+            visualTransformation = PasswordVisualTransformation(),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(
+            onClick = { onLogin(email, password) },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Iniciar sesión")
+        }
+
+        TextButton(onClick = onRegister) {
+            Text("Registrarse")
+        }
+
+        TextButton(onClick = onRecover) {
+            Text("Recuperar contraseña")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Firebase Auth dependency
- create `LoginScreen` composable
- add `LoginActivity` that stores session with `SharedPreferences`
- set `LoginActivity` as launcher activity
- fix theme usage in `MainActivity`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688056e2f550832ca296bd97e88f8f96